### PR TITLE
pytables 3.7.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,6 @@
 set HDF5_DIR=%LIBRARY_PREFIX%
 set BZIP2_DIR=%LIBRARY_PREFIX%
+set BLOSC_DIR=%LIBRARY_PREFIX%
 
 %PYTHON% setup.py install --hdf5=%LIBRARY_PREFIX% ^
                           --bzip2=%LIBRARY_PREFIX% ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,18 +7,15 @@ package:
 source:
   url: https://pypi.io/packages/source/t/tables/tables-{{ version }}.tar.gz
   sha256: e92a887ad6f2a983e564a69902de4a7645c30069fc01abd353ec5da255c5e1fe
-  patches:
-    - do_not_copy_dlls_into_package.patch
-    - remove_dll_check.patch
 
 build:
-  number: 1
+  number: 0
   entry_points:
     - pt2to3 = tables.scripts.pt2to3:main
     - ptdump = tables.scripts.ptdump:main
     - ptrepack = tables.scripts.ptrepack:main
     - pttree = tables.scripts.pttree:main
-  skip: true  # [py<35]
+  skip: true  # [py<36]
   ignore_run_exports:
     - zlib
     - lzo     # [win]
@@ -27,42 +24,52 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - m2-patch  # [win]
+    - patch     # [not win]
   host:
     - python
     - pip
-    - cython
-    - numpy-devel {{ numpy }}
-    - zlib
-    - lzo
+    - blosc >=1.4.1
     - bzip2
-    - hdf5
-    - numexpr
-    - blosc
+    - cython >=0.29.21
+    # HDF5 >= 1.8.4 (>=1.8.15 is strongly recommended),
+    # https://github.com/PyTables/PyTables/blob/v3.7.0/doc/source/usersguide/installation.rst#prerequisites
+    - hdf5 >=1.8.15
+    - lzo
+    - numexpr >=2.6.2
+    - numpy
+    - packaging
+    - setuptools >=42.0
+    - wheel
+    - zlib
   run:
     - python
-    - six
-    - numexpr
-    - hdf5
-    - zlib
-    - lzo
+    - {{ pin_compatible('numpy') }}
+    - blosc >=1.4.1
     - bzip2
-    - blosc
+    - hdf5 >=1.8.15
+    - lzo
     - mock
+    - numexpr >=2.6.2
+    - packaging
+    - zlib
 
 test:
   requires:
-    - setuptools
     - mock
+    - pip
+    - setuptools
   commands:
+    - pip check
     - pt2to3 -h
     - ptdump -h
     - ptrepack -h
     - pttree -h
 
-
 about:
-  home: http://www.pytables.org
-  license: BSD 3-Clause
+  home: https://www.pytables.org
+  license: BSD-3-Clause
+  lcense_family: BSD
   license_file: LICENSE.txt
   summary: 'Brings together Python, HDF5 and NumPy to easily handle large amounts of data.'
   description: |
@@ -70,7 +77,7 @@ about:
     efficiently and easily cope with extremely large amounts of data. PyTables
     is built on top of the HDF5 library, using the Python language and the
     NumPy package.
-  doc_url: http://www.pytables.org/
+  doc_url: https://www.pytables.org/
   dev_url: https://github.com/PyTables
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ requirements:
     - numexpr >=2.6.2
     - packaging
     - zlib
+    - zstd  # [win]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.6.1" %}
+{% set version = "3.7.0" %}
 
 package:
   name: pytables
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/tables/tables-{{ version }}.tar.gz
-  sha256: 49a972b8a7c27a8a173aeb05f67acb45fe608b64cd8e9fa667c0962a60b71b49
+  sha256: e92a887ad6f2a983e564a69902de4a7645c30069fc01abd353ec5da255c5e1fe
   patches:
     - do_not_copy_dlls_into_package.patch
     - remove_dll_check.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - m2-patch  # [win]
-    - patch     # [not win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,8 @@ requirements:
     - hdf5 >=1.8.15
     - lzo
     - numexpr >=2.6.2
-    - numpy
+    - numpy  1.19    # [py==37 or py==38 or py==39]
+    - numpy  1.21    # [py==310]
     - packaging
     - setuptools >=42.0
     - wheel


### PR DESCRIPTION
Update pytables to 3.7.0

License: https://github.com/PyTables/PyTables/blob/v3.7.0/LICENSE.txt
Release notes: https://github.com/PyTables/PyTables/blob/v3.7.0/RELEASE_NOTES.rst
Installation: https://github.com/PyTables/PyTables/blob/v3.7.0/doc/source/usersguide/installation.rst
Requirements:
- https://github.com/PyTables/PyTables/blob/v3.7.0/pyproject.toml
- https://github.com/PyTables/PyTables/blob/v3.7.0/environment.yml
- https://github.com/PyTables/PyTables/blob/v3.7.0/tables/req_versions.py
- https://github.com/PyTables/PyTables/blob/v3.7.0/setup.cfg
- https://github.com/PyTables/PyTables/blob/v3.7.0/setup.py

Actions:
1. Add in bld.bat: `set BLOSC_DIR=%LIBRARY_PREFIX%`
2. Reset build number to 0
3. Remove outdated patches and (m2)-patch
4. Skip `py<36`
5. Fix `numpy` in host:
```
    - numpy  1.19    # [py==37 or py==38 or py==39]
    - numpy  1.21    # [py==310]
```
6. Add dependency pinnings in host and run
7. Reorder dependencies in host and run
8. Use `{{ pin_compatible('numpy') }}` in run
9. Add `pip check`
10. Fix license name
11. Add license_family
12. Fix home and doc urls with HTTPS