### PR TITLE
Unpin hdf5 in host

### DIFF
--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  c3i_test2: pytables-3.8.0-b2

--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  c3i_test2: pytables-3.8.0-b2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,7 +88,7 @@ about:
     is built on top of the HDF5 library, using the Python language and the
     NumPy package.
   doc_url: https://www.pytables.org/
-  dev_url: https://github.com/PyTables
+  dev_url: https://github.com/PyTables/PyTables
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - cython 0.29.33
     - blosc 1.21.3
     - c-blosc2 2.8.0
-    - hdf5 1.12.1
+    - hdf5
     - lzo 2.10
     - bzip2 1.0.8
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - patches/use_system_blosc2.patch
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - ptdump = tables.scripts.ptdump:main
     - ptrepack = tables.scripts.ptrepack:main


### PR DESCRIPTION
The previous builds pinned `hdf5` to `v1.12.1` in the host, leading to a run constraint that is incompatible with a lot of other packages (including all of those in Anaconda Distribution that depend on `hdf5`).

Pinning `hdf5` to `v1.12.1` in host leads to the `run` dependency version constraint to look like this:
![Screen Shot 2023-05-25 at 5 35 11 PM](https://github.com/AnacondaRecipes/pytables-feedstock/assets/9688260/68a8d429-5178-4255-af28-a1c59680894b)

Which conflicts with the `hdf5` version constraint of other packages in Anaconda Distribution, like `h5py`'s:
![Screen Shot 2023-05-25 at 5 35 06 PM](https://github.com/AnacondaRecipes/pytables-feedstock/assets/9688260/7b12dfa7-1d45-433f-a420-1a8818acb56a)

Unpinning so that the [pinning in the aggregate cbc.yaml](https://github.com/AnacondaRecipes/aggregate/blob/d07d23c30c41053c55f5a35fe0c8f22e9d7301ff/conda_build_config.yaml#L98-L100) is used instead.

**Linter check:**
- `packaging` [is listed in the upstream's requirements](https://github.com/PyTables/PyTables/blob/7dd7151599edcfecab227a8813420959bb288d6d/requirements.txt#L6).