### PR TITLE
Rebuild with hdf5 1.12.1 on all platforms

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,6 +7,7 @@ set COPY_DLLS=FALSE
 set BLOSC2_LIBDIR=%LIBRARY_LIB%
 set BLOSC2_INCDIR=%LIBRARY_INC%
 set PYTABLES_NO_BLOSC2_WHEEL=1
+set PYTABLES_NO_EMBEDDED_LIBS=1
 
-%PYTHON% -m pip install --no-deps --no-build-isolation --no-cache-dir --ignore-installed .
+%PYTHON% -m pip install --no-deps --no-build-isolation --no-cache-dir --ignore-installed . -v
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,9 +8,10 @@ export BLOSC2_DIR=$PREFIX
 export COPY_DLLS=FALSE
 export BLOSC2_LIBDIR=$PREFIX/lib
 export BLOSC2_INCDIR=$PREFIX/include
-export PYTABLES_NO_BLOSC2_WHEEL
+export PYTABLES_NO_BLOSC2_WHEEL=1
+export PYTABLES_NO_EMBEDDED_LIBS=1
 
 # Remove the pre-cythonized files which may not be compatible.
 rm -f tables/*.c
 
-$PYTHON -m pip install --no-deps --no-build-isolation --no-cache-dir --ignore-installed .
+$PYTHON -m pip install --no-deps --no-build-isolation --no-cache-dir --ignore-installed . -v

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   sha256: 34f3fa2366ce20b18f1df573a77c1d27306ce1f2a41d9f9eff621b5192ea8788
   patches:
     - patches/use_system_blosc2.patch
+    - patches/0001-Don-t-copy-blosc2-in-the-package.patch
 
 build:
   number: 3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - patches/use_system_blosc2.patch
 
 build:
-  number: 2
+  number: 3
   entry_points:
     - ptdump = tables.scripts.ptdump:main
     - ptrepack = tables.scripts.ptrepack:main
@@ -21,7 +21,6 @@ build:
   # c-blosc2 is currently not available for s390x
   skip: true  # [s390x]
   ignore_run_exports:
-    - zlib
     - lzo     # [win]
 
 requirements:
@@ -43,7 +42,7 @@ requirements:
     - cython 0.29.33
     - blosc 1.21.3
     - c-blosc2 2.8.0
-    - hdf5
+    - hdf5 1.12.1
     - lzo 2.10
     - bzip2 1.0.8
   run:
@@ -55,9 +54,7 @@ requirements:
     - py-cpuinfo
     - hdf5
     - lzo
-    - lz4-c
-    - zlib-ng
-    - zstd
+    - bzip2
     - packaging
 
 test:

--- a/recipe/patches/0001-Don-t-copy-blosc2-in-the-package.patch
+++ b/recipe/patches/0001-Don-t-copy-blosc2-in-the-package.patch
@@ -1,0 +1,131 @@
+From 8e365ce40028efb6e80a662a083e87cfd42fe471 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Morin <jcmorin@anaconda.com>
+Date: Wed, 9 Aug 2023 12:10:22 -0400
+Subject: [PATCH] Don't copy blosc2 in the package. We don't want to bundle it.
+
+By default, pytables will copy blosc2 DLLs into the installed package if blosc2 is
+found in a list of hardcoded "standard" paths.
+---
+ setup.py | 106 +++++++++++++++++++++++++++----------------------------
+ 1 file changed, 53 insertions(+), 53 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 966be028..ef6e1010 100755
+--- a/setup.py
++++ b/setup.py
+@@ -813,59 +813,59 @@ if __name__ == "__main__":
+                     f"{blosc2_version}.  Update it via `pip install blosc2 -U.`"
+                 )
+ 
+-        if not rundir:
+-            loc = {
+-                "posix": "the default library paths",
+-                "nt": "any of the directories in %%PATH%%",
+-            }[os.name]
+-
+-            if package.name == "blosc2":
+-                # We will copy this into the tables directory
+-                print("  * Copying blosc2 runtime library to 'tables' dir"
+-                      " because it was not found in standard locations")
+-                platform_system = platform.system()
+-                if platform_system == "Linux":
+-                    copy_libs += ['libblosc2.so']
+-                    dll_dir = '/tmp/hdf5/lib'
+-                    # Copy dlls when producing the wheels in CI
+-                    if "bdist_wheel" in sys.argv and os.path.exists(dll_dir):
+-                        shared_libs = glob.glob(str(libdir) + '/libblosc2.so*')
+-                        for lib in shared_libs:
+-                            shutil.copy(lib, dll_dir)
+-                    else:
+-                        shutil.copy(libdir / 'libblosc2.so', 'tables')
+-                elif platform_system == "Darwin":
+-                    copy_libs += ['libblosc2.dylib']
+-                    dll_dir = '/tmp/hdf5/lib'
+-                    # Copy dlls when producing the wheels in CI
+-                    if "bdist_wheel" in sys.argv and os.path.exists(dll_dir):
+-                        shared_libs = glob.glob(str(libdir) + '/libblosc2*.dylib')
+-                        for lib in shared_libs:
+-                            shutil.copy(lib, dll_dir)
+-                    else:
+-                        shutil.copy(libdir / 'libblosc2.dylib', 'tables')
+-                else:
+-                    copy_libs += ['libblosc2.dll']
+-                    dll_dir = 'C:\\Miniconda\\envs\\build\\Library\\bin'
+-                    # Copy dlls when producing the wheels in CI
+-                    if "bdist_wheel" in sys.argv and os.path.exists(dll_dir):
+-                        shutil.copy(libdir.parent / 'bin' / 'libblosc2.dll', dll_dir)
+-                    else:
+-                        shutil.copy(libdir.parent / 'bin' / 'libblosc2.dll', 'tables')
+-            else:
+-                if "bdist_wheel" in sys.argv and os.name == "nt":
+-                    exit_with_error(
+-                        f"Could not find the {package.name} runtime.",
+-                        f"The {package.name} shared library was *not* found in "
+-                        f"{loc}. Cannot build wheel without the runtime.",
+-                    )
+-
+-                print_warning(
+-                    f"Could not find the {package.name} runtime.",
+-                    f"The {package.name} shared library was *not* found "
+-                    f"in {loc}. In case of runtime problems, please "
+-                    f"remember to install it.",
+-                )
++        # if not rundir:
++        #     loc = {
++        #         "posix": "the default library paths",
++        #         "nt": "any of the directories in %%PATH%%",
++        #     }[os.name]
++
++        #     if package.name == "blosc2":
++        #         # We will copy this into the tables directory
++        #         print("  * Copying blosc2 runtime library to 'tables' dir"
++        #               " because it was not found in standard locations")
++        #         platform_system = platform.system()
++        #         if platform_system == "Linux":
++        #             copy_libs += ['libblosc2.so']
++        #             dll_dir = '/tmp/hdf5/lib'
++        #             # Copy dlls when producing the wheels in CI
++        #             if "bdist_wheel" in sys.argv and os.path.exists(dll_dir):
++        #                 shared_libs = glob.glob(str(libdir) + '/libblosc2.so*')
++        #                 for lib in shared_libs:
++        #                     shutil.copy(lib, dll_dir)
++        #             else:
++        #                 shutil.copy(libdir / 'libblosc2.so', 'tables')
++        #         elif platform_system == "Darwin":
++        #             copy_libs += ['libblosc2.dylib']
++        #             dll_dir = '/tmp/hdf5/lib'
++        #             # Copy dlls when producing the wheels in CI
++        #             if "bdist_wheel" in sys.argv and os.path.exists(dll_dir):
++        #                 shared_libs = glob.glob(str(libdir) + '/libblosc2*.dylib')
++        #                 for lib in shared_libs:
++        #                     shutil.copy(lib, dll_dir)
++        #             else:
++        #                 shutil.copy(libdir / 'libblosc2.dylib', 'tables')
++        #         else:
++        #             copy_libs += ['libblosc2.dll']
++        #             dll_dir = 'C:\\Miniconda\\envs\\build\\Library\\bin'
++        #             # Copy dlls when producing the wheels in CI
++        #             if "bdist_wheel" in sys.argv and os.path.exists(dll_dir):
++        #                 shutil.copy(libdir.parent / 'bin' / 'libblosc2.dll', dll_dir)
++        #             else:
++        #                 shutil.copy(libdir.parent / 'bin' / 'libblosc2.dll', 'tables')
++        #     else:
++        #         if "bdist_wheel" in sys.argv and os.name == "nt":
++        #             exit_with_error(
++        #                 f"Could not find the {package.name} runtime.",
++        #                 f"The {package.name} shared library was *not* found in "
++        #                 f"{loc}. Cannot build wheel without the runtime.",
++        #             )
++
++        #         print_warning(
++        #             f"Could not find the {package.name} runtime.",
++        #             f"The {package.name} shared library was *not* found "
++        #             f"in {loc}. In case of runtime problems, please "
++        #             f"remember to install it.",
++        #         )
+ 
+ 
+         if os.name == "nt":
+-- 
+2.41.0
+


### PR DESCRIPTION
Rebuild with hdf5 1.12.1 on all platforms to have consistent dependencies. Also cleaned up dependencies.