### PR TITLE
restore original conda name

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "tables" %}
+{% set name = "pytables" %}
 {% set version = "3.9.2" %}
 
 package:
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/tables-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/t/tables/tables-{{ version }}.tar.gz
   sha256: d470263c2e50c4b7c8635a0d99ac1ff2f9e704c24d71e5fa33c4529e7d0ad9c3
   patches:
     - patches/0001-Don-t-copy-blosc2-in-the-package.patch


### PR DESCRIPTION
Changes:
- restore original conda name (tables to pytables)
- this was changed by mistake in 3.9.1.