### PR TITLE
rebuild for osx-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0002-no-python-blosc2-dep.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - ptdump = tables.scripts.ptdump:main
     - ptrepack = tables.scripts.ptrepack:main


### PR DESCRIPTION
rebuild for osx-64 - the previous merge build failed, and the packages were not uploaded.